### PR TITLE
feat: [0004] 本体v39対応、ダンおに付属モードを復活　他

### DIFF
--- a/css/kstyle.css
+++ b/css/kstyle.css
@@ -8,11 +8,6 @@
   Source Version: Ver 1.5.1
 ------------------------------------------ */
 
-/* 判定時に動いてしまうためimportantが必要 */
-div[id^="stepHit"] {
-  top: -10px !important;
-}
-
 /*
   キリズマ用ノーツ
   arrowMotion_data, frzTopMotion_dataでこのクラス名を設定

--- a/img/kirizma/arrowShadow.svg
+++ b/img/kirizma/arrowShadow.svg
@@ -1,6 +1,1 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 25.4.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="frzbar" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 500 500" style="enable-background:new 0 0 500 500;" xml:space="preserve">
-<rect y="200" width="500" height="100"/>
-</svg>
+<svg id="arrowShadow" data-name="arrowShadow" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500"><defs><style>.cls-1{stroke:#000;stroke-miterlimit:10;stroke-width:30px;}</style></defs><polygon class="cls-1" points="288.91 42.76 32.94 249.83 288.91 456.9 249.87 314.02 466.8 314.02 466.8 187.71 249.87 187.71 288.91 42.76"/></svg>


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. 本体v39対応

- Dancing☆Onigiri (CW Edition)のver39より、
機能の追加やプレイ画面構造に変化があったため対応しました。
- 具体的には、従来mainSpriteを直接回転していたところを
その子要素であるmainSprite*N*で回転することで、本体の機能が極力扱えるようにしました。
- 結果として、キリズマで機能制限があるのは次の3機能のみとなっています。

|制限される機能|理由|
|----|----|
|Effect|キリズマ部分でノーツに文字を入れる箇所で矢印モーションを利用しているため。|
|Camoufrage|キリズマでは流れてくるステップゾーンが同じ位置にいるため。|
|Swapping|Camoufrageと同じ理由|

### 2. ダンおに付属モードの復活、判定位置制限の撤廃

- ダンおに付属モード（31kkey, 51kkey等）について
1.の対応により扱いやすくなったため復活させました。
- ダンおに部分をver39から使えるようになった追加層に挿入することで実現しています。
- また、キリズマについてはダンおに本体のように押したタイミングでヒットさせることができませんでしたが、ver39の対応により可能になりました。

### 3. 矢印（影）の画像差し替え

- なぜかノートスキンのものになっていたため、差し替えました。

### 4. キリズマに関するカスタムキー定義を標準実装

- 今回より標準実装しました。
一部、カスタムキー定義も変えているのでこれまでの定義は不要になります。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->

1. ver39への対応のため。
2. ver39の構造の変化により、対応が可能となったため。
3. 画像間違いのため。
なお、これまではダンおに付属モードが使えなかったので問題ありませんでした。
4. 個別に直すのが手間のため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->

- このアップデートは本体がver39以上でないと成立しないため、
メジャーバージョンアップとします。
