### PR TITLE
fix: [0007] addTransformが未定義の場合でも処理されるよう修正

### DIFF
--- a/js/kstyle.js
+++ b/js/kstyle.js
@@ -267,7 +267,11 @@ function kstyleMainInit() {
 
 		// mainSpriteを90度回転させて移動方向を変更
 		for (let j = 0; j < Math.min(g_stateObj.layerNum, 4); j++) {
-			addTransform(`mainSprite${j}`, `kirizma`, `rotate(-90deg)`);
+			if (typeof addTransform === C_TYP_FUNCTION) {
+				addTransform(`mainSprite${j}`, `kirizma`, `rotate(-90deg)`);
+			} else {
+				$id(`mainSprite${j}`).transform = `rotate(-90deg)`;
+			}
 			$id(`mainSprite${j}`).left = `0px`;
 			$id(`mainSprite${j}`).top = `-180px`;
 		}


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. addTransform関数が未定義の場合でも処理されるよう変更

- addTransform関数はver39.1.0以降で有効な関数のため、ver39.0.0では動作しない問題がありました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 修正必須ではないのですが、管理上プレビューサイトなどで扱いにくいため、対策しました。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
