### PR TITLE
fix: [0009] ダンおに部分の相対位置指定が一部不十分だった箇所を修正

### DIFF
--- a/js/kstyle.js
+++ b/js/kstyle.js
@@ -299,7 +299,11 @@ function kstyleMainInit() {
 		// キリズマは通常より長いスクロール長のため、
 		// ダンおにが使うReverseに合わせて位置を調整
 		if (g_stateObj.layerNum > 4) {
-			$id(`mainSprite${g_stateObj._danoniRvLayer}`).top = `${g_headerObj.playingHeight - DIST_KIRIZMA}px`;
+			if (typeof addXY === C_TYP_FUNCTION) {
+				addXY(`mainSprite${g_stateObj._danoniRvLayer}`, `kirizma`, 0, g_headerObj.playingHeight - DIST_KIRIZMA);
+			} else {
+				$id(`mainSprite${g_stateObj._danoniRvLayer}`).top = `${g_headerObj.playingHeight - DIST_KIRIZMA}px`;
+			}
 		}
 
 		// キリズマ側のレーンのみ初期位置を変更


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
### 1. ダンおに部分の相対位置指定が一部不十分だった箇所を修正
- ダンおに部分の相対位置指定が一部されていない箇所があり、
重なったときにその設定が消えてしまう問題が発生していました。
addXY関数がない場合は従来通りです。

<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. ver43.1.1以降への対応のため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
