### PR TITLE
fix: [0010] 本体ver43.5.0のSideScrollの仕様変更に伴う対応

### DIFF
--- a/js/kstyle.js
+++ b/js/kstyle.js
@@ -222,24 +222,34 @@ function kstylePreloading() {
 g_customJsObj.preloading.push(kstylePreloading);
 
 /**
+ * キリズマレーンの判定
+ * @param {string|number} _val 
+ * @returns 
+ */
+const __checkKirizmaCharacter = _val => _val === `c` || String(_val).startsWith(`c:`);
+
+/**
  * プレイ開始前の割り込み処理
  * - キリズマ以外のデータが存在する場合の振り分け処理
  */
 function kstyleLoading() {
 
 	// 全てのレーン数 ＞ キリズマ側のレーン数なら矢印があると見做す
-	const keyNumMax = g_workObj.stepRtn.filter(val => val === `c`).length;
+	const keyNumMax = g_workObj.stepRtn.filter(val => __checkKirizmaCharacter(val)).length;
 	if (g_workObj.stepRtn.length > keyNumMax) {
 
 		// 矢印側はdividePosを4以上に設定する
 		// StepArea: X-FlowerがdividePosが3以下を利用するため、0～3はキリズマレーンとする
 		g_stateObj.layerNum = Math.max(g_stateObj.layerNum, 6);
 		g_workObj.stepRtn.forEach((val, j) => {
-			if (val !== `c`) {
+			if (!__checkKirizmaCharacter(val)) {
 				g_workObj.dividePos[j] = (g_workObj.scrollDir[j] === 1 ?
 					g_stateObj._danoniDfLayer : g_stateObj._danoniRvLayer);
 			}
 		})
+	}
+	if (g_stateObj.playWindow.endsWith(`SideScroll`)) {
+		g_workObj.scale = 0.95 * Math.max(g_sHeight / 600, 1);
 	}
 }
 g_customJsObj.loading.push(kstyleLoading);
@@ -275,6 +285,12 @@ function kstyleMainInit() {
 			if (typeof addXY === C_TYP_FUNCTION) {
 				addXY(`mainSprite${j}`, `kirizma`, 0, -180);
 
+				if (g_stateObj.playWindow.endsWith(`SideScroll`)) {
+					for (let j = 0; j < Math.min(g_stateObj.layerNum, 4); j++) {
+						addXY(`mainSprite${j}`, `kirizmaSc`, 60, 0);
+					}
+				}
+
 				if ([`2Step`, `Mismatched`, `R-Mismatched`].includes(g_stateObj.stepArea)
 					&& j >= Math.min(g_stateObj.layerNum, 4) / 2) {
 					// 下記の設定の場合、ステップゾーンが同じ位置にあり打ちにくいため、座標を調整
@@ -307,7 +323,7 @@ function kstyleMainInit() {
 		}
 
 		// キリズマ側のレーンのみ初期位置を変更
-		const keyNumMax = g_workObj.stepRtn.filter(val => val === `c`).length;
+		const keyNumMax = g_workObj.stepRtn.filter(val => __checkKirizmaCharacter(val)).length;
 		for (let i = 0; i < keyNumMax; i++) {
 			if (document.getElementById(`stepRoot${i}`)) {
 				document.getElementById(`stepRoot${i}`).style.left = `${pos[g_workObj.scrollDir[i]].y}px`;

--- a/js/kstyle.js
+++ b/js/kstyle.js
@@ -248,8 +248,9 @@ function kstyleLoading() {
 			}
 		})
 	}
+	// SideScrollの場合は縦横が反転するため、ウィンドウの高さによりスケールを調整
 	if (g_stateObj.playWindow.endsWith(`SideScroll`)) {
-		g_workObj.scale = 0.95 * Math.max(g_sHeight / 600, 1);
+		g_workObj.scale = 0.95 * Math.min(g_sHeight / 600, 1);
 	}
 }
 g_customJsObj.loading.push(kstyleLoading);
@@ -285,6 +286,7 @@ function kstyleMainInit() {
 			if (typeof addXY === C_TYP_FUNCTION) {
 				addXY(`mainSprite${j}`, `kirizma`, 0, -180);
 
+				// SideScrollの場合は縦横が反転するため、ウィンドウの高さにより位置を調整
 				if (g_stateObj.playWindow.endsWith(`SideScroll`)) {
 					for (let j = 0; j < Math.min(g_stateObj.layerNum, 4); j++) {
 						addXY(`mainSprite${j}`, `kirizmaSc`, 60, 0);


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
### 1. 本体ver43.5.0のSideScrollの仕様変更に伴う対応
- 本体[ver43.5.0](https://github.com/cwtickle/danoniplus/releases/tag/v43.5.0)にてSideScrollの仕様が変わりましたが、
これによりキリズマ部分が想定しない動きになっていました。
SideScrollを設定したとき、g_workObj.stepRtn[x]の値が「c」に一致せず、「c:90」になるため
関係する条件文の見直しが必要でした。
<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 最新ソースへの追従のため。
なお、ver43.5.0より前のソースであっても動作すると思います。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

<img width="60%" alt="image" src="https://github.com/user-attachments/assets/bbb99fe0-8b21-4ef1-8dee-0406f552b48a" />

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
