### PR TITLE
improve: [0011] Appearanceのフィルターバーについて31k, 51kに対応

### DIFF
--- a/js/kstyle.js
+++ b/js/kstyle.js
@@ -319,6 +319,9 @@ function kstyleMainInit() {
 		if (g_stateObj.layerNum > 4) {
 			if (typeof addXY === C_TYP_FUNCTION) {
 				addXY(`mainSprite${g_stateObj._danoniRvLayer}`, `kirizma`, 0, g_headerObj.playingHeight - DIST_KIRIZMA);
+				if ((g_hidSudObj[g_stateObj.appearance] + 1) % 2 === 0) {
+					addXY(`filterBar${4 + (g_hidSudObj[g_stateObj.appearance] + 1) % 2}`, `kirizma`, 0, g_headerObj.playingHeight - DIST_KIRIZMA);
+				}
 			} else {
 				$id(`mainSprite${g_stateObj._danoniRvLayer}`).top = `${g_headerObj.playingHeight - DIST_KIRIZMA}px`;
 			}


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
### 1. Appearanceのフィルターバーについて31k, 51kに対応
- ver44.4.1にてAppearanceのフィルターが相対位置指定に変わったことにより、
キリズマ+ダンおにモードでのフィルター追従が可能になりました。
ダンおにの片方のフィルターのみ、位置補正を行っていた関係で正しいフィルター位置にできていませんでした。


## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 本来のフィルター位置が表示できた方が違和感が少ないため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img width="60%" alt="image" src="https://github.com/user-attachments/assets/01d7be05-de1e-4417-ad12-3617d362e6e2" />

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
- ver44.4.0以前では適用してもtop属性で上書きされてしまうため、無効化されます。
- ver44.4.1以降で有効になります。