### PR TITLE
fix: [0013] v45以降のStepArea用のフィルターバー対応

### DIFF
--- a/js/kstyle.js
+++ b/js/kstyle.js
@@ -326,12 +326,50 @@ function kstyleMainInit() {
 					addXY(`arrowSprite${j}`, `kirizma`, deltaX, 0);
 					addXY(`frzHitSprite${j}`, `kirizma`, deltaX, 0);
 
+					if (__compareVersions(g_version.slice(1), `45.0.0`) >= 0 && g_appearanceRanges.includes(g_stateObj.appearance)) {
+						// Hidden+, Sudden+の場合はレイヤー毎に座標を画面中央から見てフィルターバーを外側へシフト
+						addTransform(
+							`filterBar${j}`, `kirizmaX`,
+							`translateX(calc(${g_hidSudObj[g_stateObj.appearance] === 0 ? 1 : -1} * ${deltaX}px))`,
+							g_transPriority.stepArea
+						);
+
+						// Hid&Sud+の場合は片側に2つのフィルターバーが必要なため、
+						// 追加したフィルターバーを元のフィルターバーに対して反転するようにシフト
+						if (g_stateObj.appearance === `Hid&Sud+`) {
+							addTransform(
+								`filterBar${j}_HS`, `kirizmaX`,
+								`translateX(calc(${(-1) * (g_hidSudObj[g_stateObj.appearance] === 0 ? 1 : -1)} * ${deltaX}px))`,
+								g_transPriority.stepArea
+							);
+						}
+					}
+
 				} else if (g_stateObj.stepArea === `Halfway`) {
 					// 移動距離を変えているため、Halfwayの場合も位置を調整
 					const deltaY = (j % 2 === 0 ? 1 : -1) * (DIST_KIRIZMA - g_headerObj.playingHeight) / 2;
 					addXY(`stepSprite${j}`, `kirizma`, 0, deltaY);
 					addXY(`arrowSprite${j}`, `kirizma`, 0, deltaY);
 					addXY(`frzHitSprite${j}`, `kirizma`, 0, deltaY);
+
+					if (__compareVersions(g_version.slice(1), `45.0.0`) >= 0 && g_appearanceRanges.includes(g_stateObj.appearance)) {
+						// Hidden+, Sudden+の場合はレイヤー毎に座標を画面中央から見てフィルターバーを外側へシフト
+						addTransform(
+							`filterBar${j}`, `kirizmaY`,
+							`translateY(calc(${g_hidSudObj[g_stateObj.appearance] === 0 ? 1 : -1} * ${deltaY}px))`,
+							g_transPriority.stepArea
+						);
+
+						// Hid&Sud+の場合は片側に2つのフィルターバーが必要なため、
+						// 追加したフィルターバーを元のフィルターバーに対して反転するようにシフト
+						if (g_stateObj.appearance === `Hid&Sud+`) {
+							addTransform(
+								`filterBar${j}_HS`, `kirizmaY`,
+								`translateY(calc(${(-1) * (g_hidSudObj[g_stateObj.appearance] === 0 ? 1 : -1)} * ${deltaY}px))`,
+								g_transPriority.stepArea
+							);
+						}
+					}
 				}
 			} else {
 				$id(`mainSprite${j}`).left = `0px`;


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
### 1. v45以降のStepArea用のフィルターバー対応
- 本体v45.5.2で修正した内容に関連した対応です。
- StepAreaが「Halfway」「Mismatched」「R-Mismatched」のときにキリズマでは座標補正を行っているため、
同様の対応を行う必要がありました。

<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. フィルターバーの位置が想定の位置で無いため。
なお、本体v44以前は仕様上修正が困難のため、v45（厳密にはv45.5.2以降）の対応とします。
本体v44ではフィルターバーの問題は残存しますが、その他の問題はないためそのまま動きます。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
