### PR TITLE
fix: [0014] Effectありの場合、キリズマの文字が矢印のみずれる問題を修正

### DIFF
--- a/js/kstyle.js
+++ b/js/kstyle.js
@@ -440,7 +440,7 @@ const __setKirizmaChara = (_j, _name) => {
 };
 
 g_customJsObj.makeArrow.push((_attrs, _arrowName, _name, _arrowCnt) =>
-	__setKirizmaChara(_attrs.pos, _arrowName));
+	__setKirizmaChara(_attrs.pos, `sub${_arrowName}`));
 g_customJsObj.makeFrzArrow.push((_attrs, _arrowName, _name, _arrowCnt) =>
 	__setKirizmaChara(_attrs.pos, `${_name}Top${_attrs.pos}_${_arrowCnt}`));
 

--- a/js/kstyle.js
+++ b/js/kstyle.js
@@ -263,6 +263,28 @@ g_customJsObj.loading.push(kstyleLoading);
  */
 function kstyleMainInit() {
 
+	// バージョン比較処理 (x.y.z-a1形式)
+	const __compareVersions = (versionA, versionB) => {
+		const partsA = versionA.split('-').join('.').split('.').map(j => parseInt(j, 36));
+		const partsB = versionB.split('-').join('.').split('.').map(j => parseInt(j, 36));
+		const maxLen = Math.max(partsA.length, partsB.length);
+
+		for (let i = 0; i < maxLen; i++) {
+			partsA[i] = partsA[i] || 0;
+			partsB[i] = partsB[i] || 0;
+
+			if (partsA[i] < partsB[i]) {
+				return -1; // versionA is older
+			} else if (partsA[i] > partsB[i]) {
+				return 1; // versionA is newer
+			}
+		}
+		return 0; // versionA and versionB are equal
+	};
+
+	// v45以降はEffectを掛ける対象が異なるため、分岐
+	g_workObj._arrowHeader = __compareVersions(g_version.slice(1), `45.0.0`) >= 0 ? `sub` : ``;
+
 	// キリズマのステップゾーンを移動する (キー数の末尾が'k'ならキリズマ系統と見做す)
 	if (g_keyObj.currentKey.endsWith(`k`)) {
 
@@ -270,25 +292,6 @@ function kstyleMainInit() {
 		const pos = {
 			'1': { x: 75, y: 350 },
 			'-1': { x: 530, y: 230 },
-		};
-
-		// バージョン比較処理 (x.y.z-a1形式)
-		const __compareVersions = (versionA, versionB) => {
-			const partsA = versionA.split('-').join('.').split('.').map(j => parseInt(j, 36));
-			const partsB = versionB.split('-').join('.').split('.').map(j => parseInt(j, 36));
-			const maxLen = Math.max(partsA.length, partsB.length);
-
-			for (let i = 0; i < maxLen; i++) {
-				partsA[i] = partsA[i] || 0;
-				partsB[i] = partsB[i] || 0;
-
-				if (partsA[i] < partsB[i]) {
-					return -1; // versionA is older
-				} else if (partsA[i] > partsB[i]) {
-					return 1; // versionA is newer
-				}
-			}
-			return 0; // versionA and versionB are equal
 		};
 
 		const keyCtrlPtn = `${g_keyObj.currentKey}_${g_keyObj.currentPtn}`;
@@ -440,7 +443,7 @@ const __setKirizmaChara = (_j, _name) => {
 };
 
 g_customJsObj.makeArrow.push((_attrs, _arrowName, _name, _arrowCnt) =>
-	__setKirizmaChara(_attrs.pos, `sub${_arrowName}`));
+	__setKirizmaChara(_attrs.pos, `${g_workObj._arrowHeader}${_arrowName}`));
 g_customJsObj.makeFrzArrow.push((_attrs, _arrowName, _name, _arrowCnt) =>
 	__setKirizmaChara(_attrs.pos, `${_name}Top${_attrs.pos}_${_arrowCnt}`));
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
### 1. Effectありの場合、キリズマの文字が矢印のみずれる問題を修正
- ver45以降の場合、Effectを掛ける対象が変わるため対応しました。
フリーズアローは矢印部分のみのため、そのままです。
- ver44以前でも動作するように、条件分岐で従来の名前を参照できるようにしています。

<!-- 
    変更内容をできるだけ簡潔に書いてください / A clear and concise description of what the changes is.
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. ver45への対応のため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
<!-- 懸念事項などがあれば記述してください / Add any other context about the pull request here.) -->
